### PR TITLE
Add menu option to resize only the height

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 const Artboard = require("scenegraph").Artboard;
 const {validateNum, createDialog, readConfig, writeConfig, createAlert} = require('./modules/helper');
 
-async function resizeToFit(selection) {
+async function resizeToFit(selection, keepCurrent = false) {
 	let sel = selection.items;
 	const selCount = sel.length;
 	if (!selCount) {
@@ -10,6 +10,7 @@ async function resizeToFit(selection) {
 		return false;
 	}
 	let config = await readConfig();
+	config.keepCurrent = (keepCurrent === true) ? true : config.keepCurrent;
 
 	for (let node of sel) {
 		if (0 === node.children.length) continue;
@@ -71,6 +72,10 @@ async function resizeToFit(selection) {
 	}
 }
 
+async function resizeHeightToFit(selection) {
+	await resizeToFit(selection, true);
+}
+
 async function resizeToFitPluginSettings() {
 	const defaultVal = await readConfig();
 	const dialog = createDialog(defaultVal);
@@ -100,6 +105,7 @@ async function resizeToFitPluginSettings() {
 module.exports = {
 	commands: {
 		"ResizeToFit": resizeToFit,
+		"ResizeHeightToFit": resizeHeightToFit,
 		"ResizeToFitSettings": resizeToFitPluginSettings
 	}
 };

--- a/manifest.json
+++ b/manifest.json
@@ -59,6 +59,17 @@
         {
           "type": "menu",
           "label": {
+            "default": "Resize Artboard Height to Fit Content"
+          },
+          "commandId": "ResizeHeightToFit",
+          "shortcut": {
+            "mac": "Ctrl+Alt+F",
+            "win": "Ctrl+Alt+F"
+          }
+        },
+        {
+          "type": "menu",
+          "label": {
             "default": "Settings...",
             "ja": "設定…"
           },


### PR DESCRIPTION
While this option is available in the settings, when you work with content that needs both types of resizing, it can be a pain to constantly go into the settings to toggle this option.

Note: this would need a Japanese translation.